### PR TITLE
Updated readme.txt: Replaced reference to Bitbucket and repo url Github

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ The Uncanny Toolkit for LearnDash adds the following features to your LearnDash 
 * **[LearnDash Groups in User Profiles](https://www.uncannyowl.com/knowledge-base/learndash-groups-user-profiles/?utm_medium=ldtoolkitreadme)**: Easily identify LearnDash Group membership from user profile pages.
 * **[Disable Emails](https://www.uncannyowl.com/knowledge-base/disable-emails/?utm_medium=ldtoolkitreadme)**: Easily disable all outgoing emails when troubleshooting issues.
 
-We welcome contributions to the Uncanny Toolkit! The plugin is managed in a [Bitbucket Repository](https://bitbucket.org/uncannyowl/uncanny-learndash-toolkit).
+We welcome contributions to the Uncanny Toolkit! The plugin is managed in a [GitHub Repository](https://github.com/UncannyOwl/Uncanny-Toolkit-for-LearnDash).
 
 **Ready to take your LearnDash site even further?**
 


### PR DESCRIPTION
Hi there,

When learning more about Uncanny Owl and its products, I stumbled upon a broken link to a Bitbucket repo.

I'm not sure if Bitbucket is still used by this project, but as you appear to have a Github repo that is actively used, I'm assuming that the repo migrated from Bitbucket to Github.

This PR replaces the broken link which pointed and referenced Bitbucket with your Github repo.

I couldn't find any contributor guidelines and so I apologize in advance if this PR is out-of-process.

Keep up the good work!

Cheers,
Mike